### PR TITLE
Fix getting affected rows from $statement not $pdo

### DIFF
--- a/src/PostgreSqlSwooleExtConnection.php
+++ b/src/PostgreSqlSwooleExtConnection.php
@@ -83,7 +83,7 @@ class PostgreSqlSwooleExtConnection extends Connection
             $result = $statement->execute($this->prepareBindings($bindings));
 
             $this->recordsHaveBeenModified(
-                ($count = $this->pdo->affectedRows($result)) > 0
+                ($count = $statement->affectedRows($result)) > 0
             );
 
             return $count;


### PR DESCRIPTION
`> php bin/hyperf.php migrate:reset`

```Call to undefined method Swoole\Coroutine\PostgreSQL::affectedRows()
[ERROR] Error: Call to undefined method Swoole\Coroutine\PostgreSQL::affectedRows() in /opt/www/vendor/hyperf/database-pgsql/src/PostgreSqlSwooleExtConnection.php:86
Stack trace:
#0 /opt/www/vendor/hyperf/database/src/Connection.php(1051): Hyperf\Database\PgSQL\PostgreSqlSwooleExtConnection->Hyperf\Database\PgSQL\{closure}()
#1 /opt/www/vendor/hyperf/database/src/Connection.php(1015): Hyperf\Database\Connection->runQueryCallback()
#2 /opt/www/vendor/hyperf/database-pgsql/src/PostgreSqlSwooleExtConnection.php(90): Hyperf\Database\Connection->run()
#3 /opt/www/vendor/hyperf/database/src/Connection.php(326): Hyperf\Database\PgSQL\PostgreSqlSwooleExtConnection->affectingStatement()
#4 /opt/www/vendor/hyperf/database/src/Query/Builder.php(2349): Hyperf\Database\Connection->delete()
#5 /opt/www/vendor/hyperf/database/src/Migrations/DatabaseMigrationRepository.php(107): Hyperf\Database\Query\Builder->delete()
#6 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(429): Hyperf\Database\Migrations\DatabaseMigrationRepository->delete()
#7 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(377): Hyperf\Database\Migrations\Migrator->runDown()
#8 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(399): Hyperf\Database\Migrations\Migrator->rollbackMigrations()
#9 /opt/www/vendor/hyperf/database/src/Migrations/Migrator.php(165): Hyperf\Database\Migrations\Migrator->resetMigrations()
#10 /opt/www/vendor/hyperf/database/src/Commands/Migrations/ResetCommand.php(51): Hyperf\Database\Migrations\Migrator->reset()
#11 /opt/www/vendor/hyperf/command/src/Command.php(422): Hyperf\Database\Commands\Migrations\ResetCommand->handle()
#12 [internal function]: Hyperf\Command\Command->Hyperf\Command\{closure}()
#13 {main}```