### PR TITLE
Update PostgresDriver.php

### DIFF
--- a/src/DBAL/PostgresDriver.php
+++ b/src/DBAL/PostgresDriver.php
@@ -13,20 +13,9 @@ declare(strict_types=1);
 namespace Hyperf\Database\PgSQL\DBAL;
 
 use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
-use InvalidArgumentException;
-use Swoole\Coroutine\PostgreSQL;
+use Hyperf\Database\DBAL\Concerns\ConnectsToDatabase;
 
 class PostgresDriver extends AbstractPostgreSQLDriver
 {
-    /**
-     * Create a new database connection.
-     */
-    public function connect(array $params)
-    {
-        if (! isset($params['pdo']) || ! $params['pdo'] instanceof PostgreSQL) {
-            throw new InvalidArgumentException('The "pdo" property must be required.');
-        }
-
-        return new Connection($params['pdo']);
-    }
+    use ConnectsToDatabase;
 }


### PR DESCRIPTION
fix: connect方法校验的类型必须是PostgreSQL，然而在之前hyperf/database处理时出来的pdo类型是PDO，导致migration时变更（change）字段时出现报错。 只有变更字段时会直接调用“doctrine/dbal”获得SQL语句，create table等migration动作时都是本仓库完成的，所以直接修改为按照hyperf/database的mysql一样返回PDO类型。经测试，能正常使用。